### PR TITLE
Fix imports, typo, whitespaces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ As described in depth in the documentation, the subthreshold
 parameters are estimated using linear regression and the threshold parameters are estimated 
 using maximum likelihood.  The fitting routine is built for speed: it estimates neuron parameters for 10 seconds of data 
 in about 50 seconds on a quad core Asus laptop.  *fit_neuron* also contains efficient implementations 
-of the following spike distance measures: Victor-Purpura [DA2003]_, van Rossum [VR2001]_, Schrieber [SS2003]_, and Gamma [RJ2008]_
+of the following spike distance measures: Victor-Purpura [DA2003]_, van Rossum [VR2001]_, Schreiber [SS2003]_, and Gamma [RJ2008]_
 which can be used to evaluate the accuracy of estimated models, as well as provide measures 
 of synchrony between spike trains.  
 

--- a/doc_template/tutorial.rst
+++ b/doc_template/tutorial.rst
@@ -150,17 +150,17 @@ Another Monte Carlo simulation:
    :height: 200px
    :width: 300px	
 
-Here are some figures showing values of the Schrieber similarity measure 
+Here are some figures showing values of the Schreiber similarity measure 
 for different values of the bandwidth of the Gaussian kernel :math:`\sigma`.
 
 Fitting results for neuron_1: 
 
-.. image:: neuron_1/stats/schrieber_similarity_stim14_rep0.png
+.. image:: neuron_1/stats/schreiber_similarity_stim14_rep0.png
    :height: 200px
    :width: 300px	
 
 Another Monte Carlo simulation: 
 
-.. image:: neuron_1/stats/schrieber_similarity_stim14_rep1.png
+.. image:: neuron_1/stats/schreiber_similarity_stim14_rep1.png
    :height: 200px
    :width: 300px	

--- a/fit_neuron/evaluate/__init__.py
+++ b/fit_neuron/evaluate/__init__.py
@@ -3,16 +3,16 @@ evaluate
 ~~~~~~~~~~~~
 
 This package deals with the evaluation of the parametrized models
-returned by optimization routines.  Evaluation criteria used are: 
+returned by optimization routines.  Evaluation criteria used are:
 
-1.  Voltage mean square error.  
+1.  Voltage mean square error.
 2.  Spike distance metrics.
-    
+
     a.  Gamma coincidence factor - :func:`spkd_lib.gamma_factor`
     b.  Victor Papura spike distance - :func:`spkd_lib.victor_purpura_dist`
     c.  van Rossum distance - :func:`spkd_lib.van_rossum_dist`
-    d.  Schreiber et al. similarity measure - :func:`spkd_lib.schrieber_sim`
-    
+    d.  Schreiber et al. similarity measure - :func:`spkd_lib.schreiber_sim`
+
 """
 
 from spkd_lib import *

--- a/fit_neuron/evaluate/evaluate.py
+++ b/fit_neuron/evaluate/evaluate.py
@@ -1,10 +1,10 @@
-""" 
-This simulation file runs the subthreshold model together with 
-the threshold model and plots the results against the 
-actual recordings. 
+"""
+This simulation file runs the subthreshold model together with
+the threshold model and plots the results against the
+actual recordings.
 """
 import os
-import pylab 
+import pylab
 import math
 import numpy as np
 import spkd_lib
@@ -14,49 +14,49 @@ def simulate(neuron=None,input_current_list=[],membrane_voltage_list=[],file_id_
     """
     [simulated_voltage_list,sim_file_id_list] = evaluate.simulate(neuron,input_current_list,file_id_list)
 
-    This function takes a neuron fitted from some data and 
-    simulates it against the data it is supposed to fit.  
-    
+    This function takes a neuron fitted from some data and
+    simulates it against the data it is supposed to fit.
+
     :param neuron: a neuron instance
     :param input_current_list: list of input currents
     :param membrane_voltage_list: list of voltage trace, useful for initializing neuron
     :param file_id_list: list of file ID's corresponding to input_current_list
     :param reps: number of times we want to produce simulated voltage traces for each input current in input current list
     :returns: dictionary of {file_id: simulated_voltage_list}
-    
-    .. note:: 
+
+    .. note::
         The values in the dictionary will be lists that have lengths corresponding
-        to reps.  Each element in these lists will be an array, 
+        to reps.  Each element in these lists will be an array,
         computed as a single monte carlo trial.
     """
-    
+
     simulated_voltage_dict = {}
-    
-    for (ind,input_current) in enumerate(input_current_list): 
-        
+
+    for (ind,input_current) in enumerate(input_current_list):
+
         cur_file_id = file_id_list[ind]
         V_init = membrane_voltage_list[ind][0]
         cur_voltage_list = []
         #print "Evaluating input current number: " + str(ind)
-        
+
         for cur_rep in range(reps):
             #print "Current repetition: " + str(cur_rep)
-            
+
             arr_len = len(input_current)
             simulated_voltage_arr = np.zeros((arr_len))
             simulated_voltage_arr[0] = V_init
             neuron.reset(V_init)
-            
+
             t = 0
             while t < arr_len - 1:
                 simulated_voltage_arr[t+1] = neuron.update(input_current[t])
                 t += 1
-            
+
             cur_voltage_list.append(simulated_voltage_arr)
             #simulated_voltage_dict.update(cur_file:)
-        
+
         simulated_voltage_dict.update({cur_file_id:cur_voltage_list})
-                        
+
     return simulated_voltage_dict
 
 def plot_sim_vs_real(simulated_voltage_dict=[],
@@ -66,49 +66,49 @@ def plot_sim_vs_real(simulated_voltage_dict=[],
                      fig_dir="./",
                      file_ext=".png"):
     """
-    Plots the simulated voltage traces against the actual voltage traces and 
-    saves the result as .eps file.  
-    
+    Plots the simulated voltage traces against the actual voltage traces and
+    saves the result as .eps file.
+
     :param bio_voltage_dict: dictionary, values of which are arrays of voltage traces
     :param input_voltage_dict: dictionary of input current injections, values of which are arrays of input stimuli
     :param simulated_voltage_dict: dictionary. values of which are lists of arrays of monte carlo simulated voltage traces
     :param fig_dir: directory into which figures will be plotted
     :keyword nan_as_spike: do we draw spiking lines where the traces are nan?
-    :type nan_as_spike: bool 
+    :type nan_as_spike: bool
     :keyword file_ext: file extension of plotting results
     :type file_ext: str
-    
-    .. note:: 
-        It is assumed that the keys of the dictionary inputs correspond to each 
-        other.  
+
+    .. note::
+        It is assumed that the keys of the dictionary inputs correspond to each
+        other.
     """
-    
+
     for key in input_current_dict.keys():
-    
+
         input_current = input_current_dict[key]
         membrane_voltage = bio_voltage_dict[key]
         membrane_voltage_sim_list = simulated_voltage_dict[key]
-        
+
         for (cur_rep,membrane_voltage_sim) in enumerate(membrane_voltage_sim_list):
-                
+
             pylab.figure(figsize=(20,12), dpi=200)
             data_len = len(membrane_voltage)
             x = np.array(range(0,data_len))
             y1 = membrane_voltage
             y2 = membrane_voltage_sim
             y3 = input_current
-            
+
             subplot_top = pylab.subplot(211)
-            pylab.title(key) 
+            pylab.title(key)
             pylab.plot(x, y1, color="blue", linewidth=1.0, linestyle="-", label="Membrane voltage")
             pylab.plot(x, y2, color="green", linewidth=1.0, linestyle="-", label="Simulated voltage")
             subplot_top.legend()
-            
+
             if plot_nan_as_spike:
                 spike_ind_sim = spk_from_sim([membrane_voltage_sim])[0]
             else:
                 spike_ind_sim = []
-                
+
             [pylab.axvline(x=cur_ind,linestyle = ':',color='green') for cur_ind in spike_ind_sim]
             pylab.ylim( (-80,-20) )
             pylab.xlim( (0,len(x)) )
@@ -117,10 +117,10 @@ def plot_sim_vs_real(simulated_voltage_dict=[],
             pylab.xticks(ticks,labels)
             pylab.xlabel('Time (s)')
             pylab.ylabel('Voltage (mV)')
-            
+
             #gamma = spkd_lib.gamma_factor(spike_ind_sim,spike_ind_raw,0.005)
-            #gamma_str = r"$\Gamma =" + str(gamma) + "$" 
-            
+            #gamma_str = r"$\Gamma =" + str(gamma) + "$"
+
             subplot_low = pylab.subplot(212)
             pylab.plot(x, y3, color="black", linewidth=1.0, linestyle="-",label="Input current")
             subplot_low.legend()
@@ -130,92 +130,92 @@ def plot_sim_vs_real(simulated_voltage_dict=[],
             pylab.xticks(ticks,labels)
             pylab.xlabel('Time (s)')
             pylab.ylabel('Current (A)')
-            
+
             file_str = os.path.splitext(key)[0] + "_rep" + str(cur_rep) + file_ext
-            file_path = os.path.join(fig_dir,file_str)     
-            pylab.savefig(file_path)   
+            file_path = os.path.join(fig_dir,file_str)
+            pylab.savefig(file_path)
             pylab.close()
             print "New plot: " + file_path
-        
+
 def plot_spk_performance_metrics(bio_voltage_dict,simulated_voltage_dict,fig_dir="./",file_ext=".png",dt=0.0001):
     """
-    Plots spike distance metrics for the data provided.  Metrics used are the gamma coincidence factor, 
-    the Schrieber similarity, and the van Rossum distance.  Each is plotted as a function of the
-    smoothness parameter for that particular metric.  The spike times are extracted 
-    from the voltage traces using :func:`fit_neuron.data.extract_spikes.spk_from_sim` 
-    and :func:`fit_neuron.data.extract_spikes.spk_from_bio`. 
-    
+    Plots spike distance metrics for the data provided.  Metrics used are the gamma coincidence factor,
+    the Schreiber similarity, and the van Rossum distance.  Each is plotted as a function of the
+    smoothness parameter for that particular metric.  The spike times are extracted
+    from the voltage traces using :func:`fit_neuron.data.extract_spikes.spk_from_sim`
+    and :func:`fit_neuron.data.extract_spikes.spk_from_bio`.
+
     :param bio_voltage_dict: recorded voltage traces, indexed by a file ID
     :type bio_voltage_dict: dict
     :param simulated_voltage_dict: simulated voltage traces, indexed by a file ID
-    :type simulated_voltage_dict: dict 
-    :keyword fig_dir: directory where the plots will be saved 
-    :keyword file_ext: file extension 
-    :keyword dt: time step interval 
-    
+    :type simulated_voltage_dict: dict
+    :keyword fig_dir: directory where the plots will be saved
+    :keyword file_ext: file extension
+    :keyword dt: time step interval
+
     .. note::
-        The keys of bio_voltage_dict and simulated_voltage_dict must match.  
-        In addition, there may be multiple simulations for a single file ID, 
+        The keys of bio_voltage_dict and simulated_voltage_dict must match.
+        In addition, there may be multiple simulations for a single file ID,
         but there should be a single recorded voltage trace for a file ID.
     """
-    
+
     for key in bio_voltage_dict.keys():
         membrane_voltage = bio_voltage_dict[key]
         membrane_voltage_sim_list = list(simulated_voltage_dict[key])
-        
+
         for (cur_rep,membrane_voltage_sim) in enumerate(membrane_voltage_sim_list):
             key_id = os.path.splitext(key)[0]
-            end_ext = "_" + key_id + "_rep" + str(cur_rep) + file_ext 
+            end_ext = "_" + key_id + "_rep" + str(cur_rep) + file_ext
             sim_spk_times = dt * spk_from_sim([membrane_voltage_sim])[0]
             bio_spk_times = dt * spk_from_bio([membrane_voltage])[0]
-            
+
             # --------- VAN ROSSUM -------------
             powers = np.arange(-5,5,0.25)
             van_rossum_i = [math.pow(10,power) for power in powers]
             # as tc increases, the spikes get smoothed more and more so distance will decrease
-            van_rossum_d = [spkd_lib.van_rossum_dist(bio_spk_times,sim_spk_times,tc=t_cur) for t_cur in van_rossum_i] 
+            van_rossum_d = [spkd_lib.van_rossum_dist(bio_spk_times,sim_spk_times,tc=t_cur) for t_cur in van_rossum_i]
             pylab.semilogx(van_rossum_i, van_rossum_d)
             file_str = "van_rossum_dist" + end_ext
             file_path = os.path.join(fig_dir,file_str)
             pylab.grid()
             pylab.xlabel(r'$\tau_r$')
             pylab.ylabel('van Rossum distance')
-            pylab.savefig(file_path)  
+            pylab.savefig(file_path)
             print "New plot: " + file_path
             pylab.close()
-            
+
             # --------- GAMMA FACTOR ----------------
             gamma_factor_i = np.arange(0.0,0.01,0.00005)
             gamma_factor_d = [spkd_lib.gamma_factor(sim_spk_times,bio_spk_times,delta=cur_delta) for cur_delta in gamma_factor_i]
             pylab.plot(gamma_factor_i,gamma_factor_d)
             pylab.xlabel(r'$\Delta t$')
             pylab.ylabel('Gamma coincidence factor')
-            
+
             if max(gamma_factor_d) > 0:
                 pylab.ylim( (-0.01,1.01) )
-                
+
             pylab.grid()
             file_str = "gamma_factor" + end_ext
             file_path = os.path.join(fig_dir,file_str)
-            pylab.savefig(file_path)  
+            pylab.savefig(file_path)
             print "New plot: " + file_path
             pylab.close()
-            
-            # ---------- SCHRIEBER SIMILARITY ----------
+
+            # ---------- SCHREIBER SIMILARITY ----------
             powers = np.arange(-5,5,0.25)
-            schrieber_i = [math.pow(10,power) for power in powers]
-            schrieber_d = [spkd_lib.schrieber_sim(sim_spk_times,bio_spk_times,sigma=cur_sigma) for cur_sigma in schrieber_i]
-            pylab.semilogx(schrieber_i,schrieber_d)
+            schreiber_i = [math.pow(10,power) for power in powers]
+            schreiber_d = [spkd_lib.schreiber_sim(sim_spk_times,bio_spk_times,sigma=cur_sigma) for cur_sigma in schreiber_i]
+            pylab.semilogx(schreiber_i,schreiber_d)
             pylab.xlabel(r'$\sigma$ (bandwidth of Gaussian kernel)')
-            pylab.ylabel('Schrieber similarity')
-            
+            pylab.ylabel('Schreiber similarity')
+
             if max(gamma_factor_d) > 0:
                 pylab.ylim( (-0.01,1.01) )
-            
+
             pylab.grid()
-            file_str = "schrieber_similarity" + end_ext
+            file_str = "schreiber_similarity" + end_ext
             file_path = os.path.join(fig_dir,file_str)
-            pylab.savefig(file_path)  
+            pylab.savefig(file_path)
             print "New plot: " + file_path
             pylab.close()
 
@@ -226,7 +226,7 @@ def plot_spk_performance_metrics(bio_voltage_dict,simulated_voltage_dict,fig_dir
             pylab.plot(victor_purpura_i,victor_purpura_d)
             file_str = "victor_purpura" + end_ext
             file_path = os.path.join(fig_dir,file_str)
-            pylab.savefig(file_path)  
+            pylab.savefig(file_path)
             print "New plot: " + file_path
             pylab.close()
             '''

--- a/fit_neuron/evaluate/spkd_lib.py
+++ b/fit_neuron/evaluate/spkd_lib.py
@@ -1,20 +1,13 @@
 """
 spkd_lib
 ~~~~~~~~~~~~~
-This module is a library of spike distance metrics. 
-For more information about the spike distance metrics 
+This module is a library of spike distance metrics.
+For more information about the spike distance metrics
 used below, see http://www.scholarpedia.org/article/Measures_of_spike_train_synchrony.
 """
 
-import sys
-import os 
-import numpy as np 
+import numpy as np
 from scipy import stats
-import sys
-from numpy import *
-from numpy import floor
-from numpy import zeros
-from numpy import size
 
 def get_gamma_factor(coincidence_count, model_length, target_length, target_rates, delta):
     NCoincAvg = 2 * delta * target_length * target_rates
@@ -35,27 +28,27 @@ def gamma_factor(source, target, delta, normalize=True, dt=None):
     """
     Returns the gamma precision factor between source and target trains,
     with precision delta.  See [RJ2008]_ for a more detailed description.
-    If normalize is True, the function returns the normalized gamma factor 
+    If normalize is True, the function returns the normalized gamma factor
     (less than 1.0), otherwise it returns the number of coincidences.
     dt is the precision of the trains, by default it is defaultclock.dt
-    
-    :param source: array of spike times 
-    :param target: array of spike times 
+
+    :param source: array of spike times
+    :param target: array of spike times
     :param delta: precision of coincidence detector
-    
-    .. [RJ2008] Jolivet, Renaud, et al. "A benchmark test for a quantitative assessment of simple neuron models." 
+
+    .. [RJ2008] Jolivet, Renaud, et al. "A benchmark test for a quantitative assessment of simple neuron models."
         Journal of neuroscience methods 169.2 (2008): 417-424.
     """
 
-    source = array(source)
-    target = array(target)
-    target_rate = firing_rate(target) 
+    source = np.array(source)
+    target = np.array(target)
+    target_rate = firing_rate(target)
 
     if dt is None:
         delta_diff = delta
     else:
-        source = array(rint(source / dt), dtype=int)
-        target = array(rint(target / dt), dtype=int)
+        source = np.array(rint(source / dt), dtype=int)
+        target = np.array(rint(target / dt), dtype=int)
         delta_diff = int(rint(delta / dt))
 
     source_length = len(source)
@@ -66,7 +59,7 @@ def gamma_factor(source, target, delta, normalize=True, dt=None):
 
     if (source_length > 1):
         bins = .5 * (source[1:] + source[:-1])
-        indices = digitize(target, bins)
+        indices = np.digitize(target, bins)
         diff = abs(target - source[indices])
         matched_spikes = (diff <= delta_diff)
         coincidences = sum(matched_spikes)
@@ -87,20 +80,20 @@ def gamma_factor(source, target, delta, normalize=True, dt=None):
     else:
         return coincidences
 
-def schrieber_sim(st_0,st_1,bin_width=0.0001,sigma=0.1,t_extra=0.5):
+def schreiber_sim(st_0,st_1,bin_width=0.0001,sigma=0.1,t_extra=0.5):
     """
-    Computes Schrieber similarity between two spike trains as described in [SS2003]_.
-    
-    :param st_0: array of spike times in seconds 
-    :param st_1: second array of spike times in seconds 
+    Computes Schreiber similarity between two spike trains as described in [SS2003]_.
+
+    :param st_0: array of spike times in seconds
+    :param st_1: second array of spike times in seconds
     :keyword bin_width: precision in seconds over which Gaussian convolution is computed
-    :keyword sigma: bandwidth of Gaussian kernel 
-    :keyword t_extra: how much more time in seconds after last signal do we keep convolving?   
-    
-    .. [SS2003] Schreiber, S., et al. "A new correlation-based measure of spike timing reliability." 
+    :keyword sigma: bandwidth of Gaussian kernel
+    :keyword t_extra: how much more time in seconds after last signal do we keep convolving?
+
+    .. [SS2003] Schreiber, S., et al. "A new correlation-based measure of spike timing reliability."
         Neurocomputing 52 (2003): 925-931.
     """
-    
+
     smoother_0 = stats.gaussian_kde(st_0,sigma)
     smoother_1 = stats.gaussian_kde(st_1,sigma)
     t_max = max([st_0[-1],st_1[-1]]) + t_extra
@@ -108,117 +101,117 @@ def schrieber_sim(st_0,st_1,bin_width=0.0001,sigma=0.1,t_extra=0.5):
     st_0_smooth = smoother_0(t_range)
     st_1_smooth = smoother_1(t_range)
     sim = stats.pearsonr(st_0_smooth, st_1_smooth)[0]
-    return sim 
+    return sim
 
 class ExpDecay():
     """
-    Exponentially decaying function with additive method.  
+    Exponentially decaying function with additive method.
     Useful for efficiently computing Van Rossum distance.
     """
-    
+
     def __init__(self,k=None,dt=0.0001):
 
-        self.sic_val = 0.0 
-        self.dt = dt 
-        self.k = k 
-        self.decay_factor = exp(-dt*k)
-    
+        self.sic_val = 0.0
+        self.dt = dt
+        self.k = k
+        self.decay_factor = np.exp(-dt*k)
+
     def update(self,V=0):
         self.sic_val = self.sic_val * self.decay_factor
         return self.sic_val
-    
+
     def spike(self):
-        self.sic_val += 1 
+        self.sic_val += 1
         return self.sic_val
-        
+
     def reset(self):
-        self.sic_val = 0 
+        self.sic_val = 0
 
 def van_rossum_dist(st_0,st_1,tc=1000,bin_width=0.0001,t_extra=1):
     """
     Calculates the Van Rossum distance between spike trains
-    as defined in [VR2001]_.  Note that the default parameters 
-    are optimized for inputs in units of seconds.  
-    
+    as defined in [VR2001]_.  Note that the default parameters
+    are optimized for inputs in units of seconds.
+
     :param st_0: array of spike times for first spike train
     :param st_1: array of spike times for second spike train
     :param bin_width: precision in units of time to compute integral
     :param t_extra: how much beyond max time do we keep integrating until? \
     This is necessary because the integral cannot in practice be evaluated between \
-    :math:`t=0` and :math:`t=\infty`.  
-    
-    .. [VR2001] van Rossum, Mark CW. "A novel spike distance." 
+    :math:`t=0` and :math:`t=\infty`.
+
+    .. [VR2001] van Rossum, Mark CW. "A novel spike distance."
                 Neural Computation 13.4 (2001): 751-763.
     """
-    
+
     # by default, we assume spike times are in seconds,
-    # keep integrating up to 0.5 s past last spike         
+    # keep integrating up to 0.5 s past last spike
     t_max = max([st_0[-1],st_1[-1]]) + t_extra
-    
+
     #t_min = min(st_0[0],st_0[0])
     t_range = np.arange(0,t_max,bin_width)
-    
+
     # we use a spike induced current to perform the computation
     sic = ExpDecay(k=1.0/tc,dt=bin_width)
-    
+
     f_0 = t_range * 0.0
-    f_1 = t_range * 0.0 
-    
+    f_1 = t_range * 0.0
+
     # we make copies of these arrays, since we are going to "pop" them
     s_0 = list(st_0[:])
     s_1 = list(st_1[:])
-    
+
     for (st,f) in [(s_0,f_0),(s_1,f_1)]:
         # set the internal value to zero
         sic.reset()
-        
+
         for (t_ind,t) in enumerate(t_range):
             f[t_ind] = sic.update()
             if len(st)>0:
                 if t > st[0]:
                     f[t_ind] = sic.spike()
                     st.pop(0)
-                    
+
     d = np.sqrt((bin_width / tc)* np.linalg.norm((f_0-f_1),1))
-    return d 
-                 
+    return d
+
 def victor_purpura_dist(tli,tlj,cost=1):
     """
     d=spkd(tli,tlj,cost) calculates the "spike time" distance
-    as defined [DA2003]_ for a single free parameter, 
+    as defined [DA2003]_ for a single free parameter,
     the cost per unit of time to move a spike.
-    
+
     :param tli: vector of spike times for first spike train
     :param tlj: vector of spike times for second spike train
     :keyword cost: cost per unit time to move a spike
-    :returns: spike distance metric 
-    
+    :returns: spike distance metric
+
     Translated to Python by Nicolas Jimenez from Matlab code by Daniel Reich.
-    
-    .. [DA2003] Aronov, Dmitriy. "Fast algorithm for the metric-space analysis 
-                of simultaneous responses of multiple single neurons." Journal 
+
+    .. [DA2003] Aronov, Dmitriy. "Fast algorithm for the metric-space analysis
+                of simultaneous responses of multiple single neurons." Journal
                 of Neuroscience Methods 124.2 (2003): 175-179.
-    
-    Here, the distance is 1 because there is one extra spike to be deleted at 
+
+    Here, the distance is 1 because there is one extra spike to be deleted at
     the end of the the first spike train:
-    
+
     >>> spike_time([1,2,3,4],[1,2,3],cost=1)
-    1 
-    
-    Here the distance is 1 because we shift the first spike by 0.2, 
-    leave the second alone, and shift the third one by 0.2, 
+    1
+
+    Here the distance is 1 because we shift the first spike by 0.2,
+    leave the second alone, and shift the third one by 0.2,
     adding up to 0.4:
-    
+
     >>> spike_time([1.2,2,3.2],[1,2,3],cost=1)
     0.4
 
-    Here the third spike is adjusted by 0.5, but since the cost 
-    per unit time is 0.5, the distances comes out to 0.25:  
-    
+    Here the third spike is adjusted by 0.5, but since the cost
+    per unit time is 0.5, the distances comes out to 0.25:
+
     >>> spike_time([1,2,3,4],[1,2,3,3.5],cost=0.5)
     0.25
     """
-    
+
     nspi=len(tli)
     nspj=len(tlj)
 
@@ -235,12 +228,12 @@ def victor_purpura_dist(tli,tlj,cost=1):
 
     scr[:,0] = np.arange(0,nspi+1)
     scr[0,:] = np.arange(0,nspj+1)
-           
+
     if nspi and nspj:
         for i in range(1,nspi+1):
             for j in range(1,nspj+1):
                 scr[i,j] = min([scr[i-1,j]+1, scr[i,j-1]+1, scr[i-1,j-1]+cost*abs(tli[i-1]-tlj[j-1])])
-        
+
     d=scr[nspi,nspj]
     return d
 
@@ -262,28 +255,28 @@ def find_corner_spikes(t, train, ibegin, ti, te):
 
 def bivariate_spike_distance(t1, t2, ti, te, N):
     """
-    TODO: test this function 
-    
+    TODO: test this function
+
     This Python code (including all further comments) was written by Jeremy Fix (see http://jeremy.fix.free.fr/),
     based on Matlab code written by Thomas Kreuz.
-    
+
     The SPIKE-distance is described in this paper:
-    
+
     .. [KT2013] Kreuz T, Chicharro D, Houghton C, Andrzejak RG, Mormann F:
                 Monitoring spike train synchrony.
                 J Neurophysiol 109, 1457-1472 (2013).
 
     Computes the bivariate SPIKE distance of Kreuz et al. (2012)
-    
+
     :param t1: 1D array with the spiking times of two neurons.
-    :param t2: 1D array with the spiking times of two neurons.   
+    :param t2: 1D array with the spiking times of two neurons.
     :param ti: beginning of time interval.
     :param te: end of time intervals.
     :param N: number of samples.
     :returns: Array of the values of the distance between time ti and te with N samples.
-       
+
     .. note::
-        The arrays t1, t2 and values ti, te are unit less 
+        The arrays t1, t2 and values ti, te are unit less
     """
     t = np.linspace(ti+(te-ti)/N, te, N)
     d = np.zeros(t.shape)
@@ -296,7 +289,7 @@ def bivariate_spike_distance(t1, t2, ti, te, N):
     # We compute the corner spikes for all the time instants we consider
     # corner_spikes is a 4 column matrix [t, tp1, tf1, tp2, tf2]
     corner_spikes = np.zeros((N,5))
- 
+
     ibegin_t1 = 0
     ibegin_t2 = 0
     corner_spikes[:,0] = t
@@ -322,7 +315,7 @@ def bivariate_spike_distance(t1, t2, ti, te, N):
     df2 = np.min(np.fabs(np.tile(t1,(N,1)) - np.tile(np.reshape(corner_spikes[:,4],(N,1)),t1.size)),axis=1)
 
     xp1 = t - corner_spikes[:,1]
-    xf1 = corner_spikes[:,2] - t 
+    xf1 = corner_spikes[:,2] - t
     xp2 = t - corner_spikes[:,3]
     xf2 = corner_spikes[:,4] - t
 
@@ -400,7 +393,7 @@ def test_biv_spk():
     spike_times[:,range(num_spikes/2)] = tf/2.0 * np.random.random((num_trains, num_spikes/2))
     # We now append the times for the events with increasing jitter
     for i in range(1,num_events+1):
-        tb = tf/2.0 * i / num_events 
+        tb = tf/2.0 * i / num_events
         spike_times[:,num_spikes/2+i-1] = tb + (50 *(i-1) / num_events)* (2.0 * np.random.random((num_trains,)) - 1)
 
     # And the second events with the decreasing jitter
@@ -410,8 +403,8 @@ def test_biv_spk():
         spike_times[:, -(i+1)] = tb + (50 - 50 *i / (num_last_events-1))* (2.0 * np.random.random((num_trains,)) - 1)
 
     # Finally we sort the spike times by increasing time for each neuron
-    spike_times.sort(axis=1) 
-    
+    spike_times.sort(axis=1)
+
     # We compute the multivariate SPIKE distance
     list_spike_trains = []
     [list_spike_trains.append(spike_times[i,:]) for i in range(num_trains)]
@@ -434,7 +427,7 @@ def test_biv_spk():
     plt.savefig("kreuz_multivariate.png")
 
     plt.show()
-    
+
 def test():
     st_0 = [1,2,3,4]
     st_1 = [1,2,3,4.002]
@@ -442,14 +435,14 @@ def test():
     d2 = victor_purpura_dist(st_0,st_1)
     #(source, target, delta, normalize=True, dt=None):
     d3 = gamma_factor(st_0,st_1,0.004)
-    d4 = schrieber_sim(st_0,st_1,sigma=0.1)
+    d4 = schreiber_sim(st_0,st_1,sigma=0.1)
     print "Spike train 1: " + str(st_0)
     print "Spike train 2: " + str(st_1)
     print "Van rossum distance: " + str(d1)
     print "Victor Purpura distance: " + str(d2)
     print "Gamma factor: " + str(d3)
-    print "Schrieber similarity: " + str(d4)
-    
-    
+    print "Schreiber similarity: " + str(d4)
+
+
 if __name__ == '__main__':
     test()


### PR DESCRIPTION
- fixed typo: Schrieber->Schreiber consistently
  NB: also for function names!

In module fit_neuron/evaluate:
- removed trailing whitespaces
- fixed superfluous and redundant import statements
  in spkd_lib.py
